### PR TITLE
chore: add license metadata to project files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [versionize](https://github.com/versionize/versionize) for commit guidelines.
 
+<a name="0.4.0-alpha.7"></a>
+## [0.4.0-alpha.7](https://www.github.com/jlbarreda/dev-elf/releases/tag/v0.4.0-alpha.7) (2025-09-30)
+
 <a name="0.4.0-alpha.6"></a>
 ## [0.4.0-alpha.6](https://www.github.com/jlbarreda/dev-elf/releases/tag/v0.4.0-alpha.6) (2025-09-30)
 

--- a/src/DevElf.Logging/DevElf.Logging.csproj
+++ b/src/DevElf.Logging/DevElf.Logging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.4.0-alpha.6</Version>
+    <Version>0.4.0-alpha.7</Version>
     <PackageId>DevElf.Logging</PackageId>
     <Authors>Jose Luis Barreda Guerena</Authors>
     <Company>Jose Luis Barreda Guerena</Company>

--- a/src/DevElf.Logging/DevElf.Logging.csproj
+++ b/src/DevElf.Logging/DevElf.Logging.csproj
@@ -7,10 +7,12 @@
     <Company>Jose Luis Barreda Guerena</Company>
     <Description>Logging extensions and tools for .NET applications.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="../../LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DevElf/DevElf.csproj
+++ b/src/DevElf/DevElf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.4.0-alpha.6</Version>
+    <Version>0.4.0-alpha.7</Version>
     <PackageId>DevElf</PackageId>
     <Authors>Jose Luis Barreda Guerena</Authors>
     <Company>Jose Luis Barreda Guerena</Company>

--- a/src/DevElf/DevElf.csproj
+++ b/src/DevElf/DevElf.csproj
@@ -7,10 +7,12 @@
     <Company>Jose Luis Barreda Guerena</Company>
     <Description>Extensions and tools for .NET applications.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="../../LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
chore: add license metadata to project files

Added `<PackageLicenseExpression>` with `Apache-2.0` to both
`DevElf.Logging.csproj` and `DevElf.csproj` to specify the
license type. Included the `LICENSE` file in the package
distribution by adding it to the `<ItemGroup>` in both
project files.