### PR TITLE
ci: reduce permissions in release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
   id-token: write
   checks: write
   pull-requests: write


### PR DESCRIPTION
The `permissions` section in `release.yml` was updated to remove the following write permissions:
- `packages`
- `id-token`
- `checks`
- `pull-requests`

This change limits the scope of actions the workflow can perform, potentially improving security.