### PR TITLE
feat: add FrozenTimeProvider and time extensions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@
 - Prefer `nameof` over `typeof` where applicable.
 - Use tuple swap syntax for swapping values.
 - Use static local functions where possible.
-- Add an empty line before `return`, `throw`, `break`, `yield`, and `continue`.
+- Add an empty line before `return`, `throw`, `break`, `yield`, and `continue`, when it's not the only line. If the previous line is a comment, the empty line should be added before the comment.
 - Place a blank line between method declarations.
 - Avoid multiple statements on a single line.
 - Align parameters and arguments vertically with one level of indentation.

--- a/src/DevElf/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/DevElf/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,39 @@
+namespace DevElf.Extensions;
+
+/// <summary>
+/// Extension helpers for <see cref="DateTimeOffset"/> conversions to <see cref="DateOnly"/> and <see cref="TimeOnly"/>.
+/// </summary>
+public static class DateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns the date component of the provided <see cref="DateTimeOffset"/> as a <see cref="DateOnly"/>.
+    /// The date portion is taken from the <see cref="DateTimeOffset.Date"/> property.
+    /// </summary>
+    public static DateOnly ToDateOnly(this DateTimeOffset dateTimeOffset)
+        => DateOnly.FromDateTime(dateTimeOffset.Date);
+
+    /// <summary>
+    /// Returns the local date component of the provided <see cref="DateTimeOffset"/> as a <see cref="DateOnly"/>.
+    /// </summary>
+    public static DateOnly ToLocalDateOnly(this DateTimeOffset dateTimeOffset)
+        => DateOnly.FromDateTime(dateTimeOffset.LocalDateTime);
+
+    /// <summary>
+    /// Returns the UTC date component of the provided <see cref="DateTimeOffset"/> as a <see cref="DateOnly"/>.
+    /// </summary>
+    public static DateOnly ToUtcDateOnly(this DateTimeOffset dateTimeOffset)
+        => DateOnly.FromDateTime(dateTimeOffset.UtcDateTime);
+
+    /// <summary>
+    /// Returns the time-of-day component as a <see cref="TimeOnly"/>.
+    /// This represents the time portion in the offset's time zone.
+    /// </summary>
+    public static TimeOnly TimeOfDayAsTimeOnly(this DateTimeOffset dateTimeOffset)
+        => TimeOnly.FromTimeSpan(dateTimeOffset.TimeOfDay);
+
+    /// <summary>
+    /// Returns the local time-of-day component as a <see cref="TimeOnly"/>.
+    /// </summary>
+    public static TimeOnly LocalTimeOfDayAsTimeOnly(this DateTimeOffset dateTimeOffset)
+        => TimeOnly.FromTimeSpan(dateTimeOffset.LocalDateTime.TimeOfDay);
+}

--- a/src/DevElf/Extensions/TimeProviderExtensions.cs
+++ b/src/DevElf/Extensions/TimeProviderExtensions.cs
@@ -1,0 +1,100 @@
+using DevElf.ArgumentValidation;
+
+namespace DevElf.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="TimeProvider"/> to provide convenient conversions and helpers.
+/// </summary>
+public static class TimeProviderExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="FrozenTimeProvider"/> that is frozen to the current instant of <paramref name="timeProvider"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>A frozen time provider.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static TimeProvider Freeze(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return new FrozenTimeProvider(timeProvider);
+    }
+
+    /// <summary>
+    /// Returns the current local time from the provider as a <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current local <see cref="DateTime"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static DateTime GetLocalNowAsDateTime(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetLocalNow().LocalDateTime;
+    }
+
+    /// <summary>
+    /// Returns the current UTC time from the provider as a <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current UTC <see cref="DateTime"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static DateTime GetUtcNowAsDateTime(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>
+    /// Returns the current local date from the provider as a <see cref="DateOnly"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current local <see cref="DateOnly"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static DateOnly GetToday(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetLocalNow().ToDateOnly();
+    }
+
+    /// <summary>
+    /// Returns the current UTC date from the provider as a <see cref="DateOnly"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current UTC <see cref="DateOnly"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static DateOnly GetUtcToday(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetUtcNow().ToDateOnly();
+    }
+
+    /// <summary>
+    /// Returns the current local time-of-day from the provider as a <see cref="TimeOnly"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current local <see cref="TimeOnly"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static TimeOnly GetTimeOfDay(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetLocalNow().TimeOfDayAsTimeOnly();
+    }
+
+    /// <summary>
+    /// Returns the current UTC time-of-day from the provider as a <see cref="TimeOnly"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider.</param>
+    /// <returns>The current UTC <see cref="TimeOnly"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public static TimeOnly GetUtcTimeOfDay(this TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        return timeProvider.GetUtcNow().TimeOfDayAsTimeOnly();
+    }
+}

--- a/src/DevElf/FrozenTimeProvider.cs
+++ b/src/DevElf/FrozenTimeProvider.cs
@@ -1,0 +1,39 @@
+using DevElf.ArgumentValidation;
+
+namespace DevElf;
+
+/// <summary>
+/// A <see cref="TimeProvider"/> that always returns a fixed point in time.
+/// Useful for tests and deterministic time-dependent logic.
+/// </summary>
+public sealed class FrozenTimeProvider : TimeProvider
+{
+    private readonly DateTimeOffset _utcNow;
+
+    /// <summary>
+    /// Creates a new instance that will always return the provided instant in UTC.
+    /// The provided <see cref="DateTimeOffset"/> is converted to UTC internally.
+    /// </summary>
+    /// <param name="now">The instant to freeze.</param>
+    public FrozenTimeProvider(DateTimeOffset now)
+        => this._utcNow = now.ToUniversalTime();
+
+    /// <summary>
+    /// Creates a new instance that is frozen to the current value of the
+    /// specified <see cref="TimeProvider"/>.
+    /// </summary>
+    /// <param name="timeProvider">The source time provider used to obtain the instant to freeze.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="timeProvider"/> is <see langword="null"/>.</exception>
+    public FrozenTimeProvider(TimeProvider timeProvider)
+    {
+        timeProvider.ThrowIfNull();
+
+        this._utcNow = timeProvider.GetUtcNow();
+    }
+
+    /// <summary>
+    /// Returns the frozen instant as a UTC <see cref="DateTimeOffset"/>.
+    /// </summary>
+    /// <returns>The frozen UTC instant.</returns>
+    public override DateTimeOffset GetUtcNow() => this._utcNow;
+}

--- a/tests/DevElf.Logging.Tests/LogMessageScopeAccessorTests.cs
+++ b/tests/DevElf.Logging.Tests/LogMessageScopeAccessorTests.cs
@@ -94,7 +94,7 @@ public class LogMessageScopeAccessorTests
         await Task.Yield();
         _ = accessor.Current.Should().BeSameAs(scope);
 
-        await Task.Delay(1, TestContext.CancellationTokenSource.Token);
+        await Task.Delay(1, TestContext.CancellationToken);
         _ = accessor.Current.Should().BeSameAs(scope);
 
         // Act & Assert: inside a child task (ExecutionContext flows by default)
@@ -105,7 +105,7 @@ public class LogMessageScopeAccessorTests
                 await Task.Yield();
                 _ = accessor.Current.Should().BeSameAs(scope);
             },
-            TestContext.CancellationTokenSource.Token);
+            TestContext.CancellationToken);
 
         // Act
         scope.Dispose();

--- a/tests/DevElf.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/tests/DevElf.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -1,0 +1,122 @@
+using AwesomeAssertions;
+using DevElf.Extensions;
+
+namespace DevElf.Tests.Extensions;
+
+[TestClass]
+public class DateTimeOffsetExtensionsTests
+{
+    [TestMethod]
+    public void ToDateOnly_returns_date_component()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 13, 30, 0, TimeSpan.FromHours(2));
+
+        // Act
+        var result = dto.ToDateOnly();
+
+        // Assert
+        _ = result.Year.Should().Be(2025);
+        _ = result.Month.Should().Be(4);
+        _ = result.Day.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void ToLocalDateOnly_returns_local_date_component()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 23, 0, 0, TimeSpan.FromHours(3));
+
+        // Act
+        var result = dto.ToLocalDateOnly();
+
+        // Assert
+        _ = result.Should().Be(DateOnly.FromDateTime(dto.LocalDateTime));
+    }
+
+    [TestMethod]
+    public void ToUtcDateOnly_returns_utc_date_component()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 23, 0, 0, TimeSpan.FromHours(3));
+
+        // Act
+        var result = dto.ToUtcDateOnly();
+
+        // Assert
+        _ = result.Should().Be(DateOnly.FromDateTime(dto.UtcDateTime));
+    }
+
+    [TestMethod]
+    public void TimeOfDayAsTimeOnly_returns_time_of_day()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 6, 7, 8, TimeSpan.FromHours(-5));
+
+        // Act
+        var result = dto.TimeOfDayAsTimeOnly();
+
+        // Assert
+        _ = result.Should().Be(TimeOnly.FromTimeSpan(dto.TimeOfDay));
+    }
+
+    [TestMethod]
+    public void LocalTimeOfDayAsTimeOnly_returns_local_time_of_day()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 18, 30, 0, TimeSpan.FromHours(1));
+
+        // Act
+        var result = dto.LocalTimeOfDayAsTimeOnly();
+
+        // Assert
+        _ = result.Should().Be(TimeOnly.FromTimeSpan(dto.LocalDateTime.TimeOfDay));
+    }
+
+    [TestMethod]
+    public void ToDateOnly_and_ToUtcDateOnly_do_not_convert_each_other_when_offset_changes_day()
+    {
+        // Arrange: choose a local date/time that when converted to UTC falls on the previous day
+        var dto = new DateTimeOffset(2025, 4, 5, 0, 30, 0, TimeSpan.FromHours(3));
+
+        // Act
+        var localDate = dto.ToDateOnly();
+        var utcDate = dto.ToUtcDateOnly();
+
+        // Assert: the two dates should be distinct and reflect the offset semantics
+        _ = localDate.Should().Be(DateOnly.FromDateTime(dto.Date));
+        _ = utcDate.Should().Be(DateOnly.FromDateTime(dto.UtcDateTime));
+        _ = localDate.Should().NotBe(utcDate);
+    }
+
+    [TestMethod]
+    public void TimeOfDayAsTimeOnly_is_not_converted_to_utc_time_of_day()
+    {
+        // Arrange: choose an offseted time where UTC time-of-day differs
+        var dto = new DateTimeOffset(2025, 4, 5, 1, 15, 0, TimeSpan.FromHours(5));
+
+        // Act
+        var localTimeOnly = dto.TimeOfDayAsTimeOnly();
+        var utcTimeOnly = TimeOnly.FromTimeSpan(dto.UtcDateTime.TimeOfDay);
+
+        // Assert: local time-of-day reflects the offset's time, not UTC
+        _ = localTimeOnly.Should().Be(TimeOnly.FromTimeSpan(dto.TimeOfDay));
+        _ = localTimeOnly.Should().NotBe(utcTimeOnly);
+    }
+
+    [TestMethod]
+    public void ToLocalDateOnly_differs_from_ToDateOnly_when_system_timezone_differs_from_offset()
+    {
+        // Arrange: create a DateTimeOffset with an offset different from the system's local time
+        // using a positive offset that would differ from most system timezones
+        var dto = new DateTimeOffset(2025, 4, 5, 12, 0, 0, DateTimeOffset.Now.Offset + TimeSpan.FromHours(2));
+
+        // Act
+        var dateOnly = dto.ToDateOnly();
+        var localDateOnly = dto.ToLocalDateOnly();
+
+        // Assert: ToDateOnly uses the offset's date, ToLocalDateOnly converts to system local time
+        _ = dateOnly.Should().Be(DateOnly.FromDateTime(dto.Date));
+        _ = localDateOnly.Should().Be(DateOnly.FromDateTime(dto.LocalDateTime));
+    }
+}

--- a/tests/DevElf.Tests/Extensions/TimeProviderExtensionsTests.cs
+++ b/tests/DevElf.Tests/Extensions/TimeProviderExtensionsTests.cs
@@ -1,0 +1,96 @@
+using AwesomeAssertions;
+using DevElf.Extensions;
+
+namespace DevElf.Tests.Extensions;
+
+[TestClass]
+public class TimeProviderExtensionsTests
+{
+    [TestMethod]
+    public void FrozenTimeProvider_GetUtcNow_returns_utc_instant()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 12, 0, 0, TimeSpan.FromHours(2));
+
+        // Act
+        var frozen = new FrozenTimeProvider(dto);
+
+        // Assert
+        _ = frozen.GetUtcNow().Should().Be(dto.ToUniversalTime());
+    }
+
+    [TestMethod]
+    public void Freeze_returns_frozen_provider_with_same_utc()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2023, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var frozen = new FrozenTimeProvider(dto);
+
+        // Act
+        var frozen2 = frozen.Freeze();
+
+        // Assert
+        _ = frozen2.GetUtcNow().Should().Be(frozen.GetUtcNow());
+    }
+
+    [TestMethod]
+    public void GetUtcNowAsDateTime_returns_utc_date_time()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2024, 6, 7, 8, 9, 10, TimeSpan.FromHours(-4));
+        var frozen = new FrozenTimeProvider(dto);
+
+        // Act
+        var result = frozen.GetUtcNowAsDateTime();
+
+        // Assert
+        _ = result.Should().Be(frozen.GetUtcNow().UtcDateTime);
+    }
+
+    [TestMethod]
+    public void GetLocalNowAsDateTime_returns_local_date_time()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2022, 12, 31, 23, 0, 0, TimeSpan.FromHours(1));
+        var frozen = new FrozenTimeProvider(dto);
+
+        // Act
+        var result = frozen.GetLocalNowAsDateTime();
+
+        // Assert
+        _ = result.Should().Be(frozen.GetLocalNow().LocalDateTime);
+    }
+
+    [TestMethod]
+    public void GetToday_and_GetUtcToday_and_time_of_day_methods_return_expected_values()
+    {
+        // Arrange
+        var dto = new DateTimeOffset(2025, 4, 5, 18, 45, 30, TimeSpan.FromHours(2));
+        var frozen = new FrozenTimeProvider(dto);
+
+        // Act
+        var today = frozen.GetToday();
+        var utcToday = frozen.GetUtcToday();
+        var timeOfDay = frozen.GetTimeOfDay();
+        var utcTimeOfDay = frozen.GetUtcTimeOfDay();
+
+        // Assert
+        _ = today.Should().Be(DateOnly.FromDateTime(frozen.GetLocalNow().LocalDateTime));
+        _ = utcToday.Should().Be(DateOnly.FromDateTime(frozen.GetUtcNow().UtcDateTime));
+        _ = timeOfDay.Should().Be(TimeOnly.FromTimeSpan(frozen.GetLocalNow().TimeOfDay));
+        _ = utcTimeOfDay.Should().Be(TimeOnly.FromTimeSpan(frozen.GetUtcNow().TimeOfDay));
+    }
+
+    [TestMethod]
+    public void Freeze_throws_ArgumentNullException_when_timeProvider_is_null()
+    {
+        // Arrange
+        TimeProvider? timeProvider = null;
+
+        // Act
+        Action act = () => timeProvider!.Freeze();
+
+        // Assert
+        _ = act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
Introduced `FrozenTimeProvider` for deterministic time handling and added `DateTimeOffsetExtensions` and `TimeProviderExtensions` for convenient conversions to `DateOnly` and `TimeOnly`.

Refactored `LogMessageScopeAccessorTests` and `LogMessageScopeManualTests` to improve readability by adopting modern C# features like `using` declarations. Replaced `TestContext.CancellationTokenSource.Token` with `TestContext.CancellationToken`.

Added comprehensive unit tests for new extensions and `FrozenTimeProvider` to ensure correctness, including edge cases for time zone handling.

Improved code quality and maintainability by leveraging null-checking extensions and enhancing test coverage.